### PR TITLE
Update log4j to 2.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ AssertLogData.assertLogContains(List<String> in_filePathList, ParseDefinition in
 
 ## Release Notes
 - 1.0.6
-  - #39 updated the log4J library to 2.16.0 to avoid the PSIRT vulnerability
+  - #39 updated the log4J library to 2.17.0 to avoid the PSIRT vulnerability
   - #38 Resolved some issues with HashCode
   - #37 Upgraded the build to Java11
   - #34 Activated sonar in the build process

--- a/pom.xml
+++ b/pom.xml
@@ -314,12 +314,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
This fixes CVE: https://nvd.nist.gov/vuln/detail/CVE-2021-45105