### PR TITLE
Update to log4j 2.17.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ AssertLogData.assertLogContains(List<String> in_filePathList, ParseDefinition in
 
 ## Release Notes
 - 1.0.7
-  - #39 updated the log4J library to 2.17.0 to avoid the PSIRT vulnerability
+  - #39 updated the log4J library to 2.17.1 to avoid the PSIRT vulnerability
 - 1.0.6
   - #38 Resolved some issues with HashCode
   - #37 Upgraded the build to Java11

--- a/pom.xml
+++ b/pom.xml
@@ -314,12 +314,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
This fixes https://nvd.nist.gov/vuln/detail/CVE-2021-44832