### PR TITLE
Fixed issue #169 where too many Parse definition entries where added …

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,11 +459,10 @@ All reports are stored in the directory `log-parser-reports/export/`.
 - **(new feature)** [#141](https://github.com/adobe/log-parser/issues/141) You can now export a LogData as a table in a HTML file.
 - **(new feature)** [#123](https://github.com/adobe/log-parser/issues/123) We now log the total number and size of the parsed files.
 - [#110](https://github.com/adobe/log-parser/issues/110) Moved to Java 11
-- [#112](https://github.com/adobe/log-parser/issues/112) Updating License Headers
+- [#169](https://github.com/adobe/log-parser/issues/169) We only keep one Parse Definition entry with the same title in a Parse Definition.
 - [#157](https://github.com/adobe/log-parser/issues/157) Search terms ar no longer a Map of key and Objects. Instead, they are now a map of Parse Definition Entry names and Hamcrest Matchers. This may cause compilation errors for those using the search & filter functions. For migration purposes please refer to the section on [Defining a Search Term](#defining-a-search-term).
 - [#119](https://github.com/adobe/log-parser/issues/119) Cleanup of deprecated methods, and the consequences thereof.
 - [#137](https://github.com/adobe/log-parser/issues/137) We can now generate an HTML report for the differences in log data.
-- [#169](https://github.com/adobe/log-parser/issues/169) Bug in enrichment when enriching more than once for the same field. We would create duplicate parse definition entries.
 
 ### 1.0.10
 - Moved main code and tests to the package "core"

--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ All reports are stored in the directory `log-parser-reports/export/`.
 - [#157](https://github.com/adobe/log-parser/issues/157) Search terms ar no longer a Map of key and Objects. Instead, they are now a map of Parse Definition Entry names and Hamcrest Matchers. This may cause compilation errors for those using the search & filter functions. For migration purposes please refer to the section on [Defining a Search Term](#defining-a-search-term).
 - [#119](https://github.com/adobe/log-parser/issues/119) Cleanup of deprecated methods, and the consequences thereof.
 - [#137](https://github.com/adobe/log-parser/issues/137) We can now generate an HTML report for the differences in log data.
+- [#169](https://github.com/adobe/log-parser/issues/169) Bug in enrichment when enriching more than once for the same field. We would create duplicate parse definition entries.
 
 ### 1.0.10
 - Moved main code and tests to the package "core"

--- a/src/main/java/com/adobe/campaign/tests/logparser/core/ParseDefinition.java
+++ b/src/main/java/com/adobe/campaign/tests/logparser/core/ParseDefinition.java
@@ -73,7 +73,7 @@ public class ParseDefinition {
 
     /**
      * This method adds a definition entry to the definition entries of this
-     * parse definition
+     * parse definition. This is provided there are no existing entries with the same title
      *
      * Author : gandomi
      *
@@ -83,8 +83,9 @@ public class ParseDefinition {
      *
      */
     public void addEntry(ParseDefinitionEntry in_parseDefinitionEntry) {
-        getDefinitionEntries().add(in_parseDefinitionEntry);
-
+        if (this.getDefinitionEntries().stream().noneMatch(e -> e.getTitle().equals(in_parseDefinitionEntry.getTitle()))) {
+            this.getDefinitionEntries().add(in_parseDefinitionEntry);
+        }
     }
 
     @Override

--- a/src/test/java/com/adobe/campaign/tests/logparser/core/ParseDefinitionTests.java
+++ b/src/test/java/com/adobe/campaign/tests/logparser/core/ParseDefinitionTests.java
@@ -71,6 +71,27 @@ public class ParseDefinitionTests {
 
     }
 
+    @Test(description = "Related to the issue #169")
+    public void testAddingDuplicateEntries() {
+        ParseDefinition l_parseDefinition = new ParseDefinition("rest calls");
+
+        l_parseDefinition.addEntry(new ParseDefinitionEntry("One"));
+        l_parseDefinition.addEntry(new ParseDefinitionEntry("One"));
+
+        assertThat("The size of the definition should be 1", l_parseDefinition.getDefinitionEntries().size(), is(1));
+    }
+
+    @Test(description = "Related to the issue #169")
+    public void testAddingDifferentEntries() {
+        ParseDefinition l_parseDefinition = new ParseDefinition("rest calls");
+
+        l_parseDefinition.addEntry(new ParseDefinitionEntry("One"));
+        l_parseDefinition.addEntry(new ParseDefinitionEntry("Two"));
+
+        assertThat("The size of the definition should be 1", l_parseDefinition.getDefinitionEntries().size(), is(2));
+    }
+
+
     @Test
     public void testcopyConstructorParseDefinition() {
 


### PR DESCRIPTION
…when enrichment was called more than ones for the same definition entry

<!--- Provide a general summary of your changes in the Title above -->

## Description

When enrichment is called multiple times for the same field we add the parse definition entry esaully often.

## Related Issue
Fixes #169 


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual and automated

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ x] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
