### PR TITLE
57 allow asserts to use matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,9 +398,17 @@ We currently have the following assertions:
         AssertLogData.assertLogContains(LogData<T> in_logData, String in_entryTitle, Matcher in_expectedCondition)
         AssertLogData.assertLogContains(String description, LogData<T> in_logData, String in_entryTitle, Matcher in_expectedCondition)
 
-        AssertLogData.assertLogContains(LogData<T> in_logData, String in_entryTitle, Map<Matcher> in_expectedConditions)
-        AssertLogData.assertLogContains(String description, LogData<T> in_logData, String in_entryTitle, Map<Matcher> in_expectedConditions)
+        AssertLogData.assertLogContains(LogData<T> in_logData, Map<String, Matcher> in_expectedConditions)
+        AssertLogData.assertLogContains(String description, LogData<T> in_logData, Map<String, Matcher> in_expectedConditions)
 ```
+
+You have two types of assertions. A simple one where you give an entry key and a matcher, and a more complex one where you give a map of parse Definition Entry keys entries and corresponding matchers.
+
+An assertion will only work if:
+* The log data is not empty
+* There is a Parse Definition entry with the given title.
+
+Otherwise, you will get a failed assertion for these causes.
 
 ## Exporting Parse Results
 We have the possibility to export the log data results into files. Currently the following formats are supported:

--- a/README.md
+++ b/README.md
@@ -395,14 +395,12 @@ As of version 1.0.5 we have introduced the notion of assertions. Assertions can 
 We currently have the following assertions:
 
 ```java
-AssertLogData.assertLogContains(LogData<T> in_logData, String in_entryTitle, String in_expectedValue)
+        AssertLogData.assertLogContains(LogData<T> in_logData, String in_entryTitle, Matcher in_expectedCondition)
+        AssertLogData.assertLogContains(String description, LogData<T> in_logData, String in_entryTitle, Matcher in_expectedCondition)
 
-AssertLogData.assertLogContains(List<String> in_filePathList, ParseDefinition in_parseDefinition, String in_entryTitle, String in_expectedValue)
+        AssertLogData.assertLogContains(LogData<T> in_logData, String in_entryTitle, Map<Matcher> in_expectedConditions)
+        AssertLogData.assertLogContains(String description, LogData<T> in_logData, String in_entryTitle, Map<Matcher> in_expectedConditions)
 ```
-`AssertLogData.assertLogContains(LogData<T>, String, String )` allows you to perform an assertion on an existing LogData Object. 
-
-
-`AssertLogData.assertLogContains(List<String>, ParseDefinition, String, String)` allows you to perform an assertion directly on a file. 
 
 ## Exporting Parse Results
 We have the possibility to export the log data results into files. Currently the following formats are supported:
@@ -461,6 +459,7 @@ All reports are stored in the directory `log-parser-reports/export/`.
 - [#110](https://github.com/adobe/log-parser/issues/110) Moved to Java 11
 - [#169](https://github.com/adobe/log-parser/issues/169) We only keep one Parse Definition entry with the same title in a Parse Definition.
 - [#157](https://github.com/adobe/log-parser/issues/157) Search terms ar no longer a Map of key and Objects. Instead, they are now a map of Parse Definition Entry names and Hamcrest Matchers. This may cause compilation errors for those using the search & filter functions. For migration purposes please refer to the section on [Defining a Search Term](#defining-a-search-term).
+- [#57](https://github.com/adobe/log-parser/issues/57) Assertions are no longer an implicite assert equal method. We now allow Hamcrest Matchers for asserting. This can be one or more matchers.
 - [#119](https://github.com/adobe/log-parser/issues/119) Cleanup of deprecated methods, and the consequences thereof.
 - [#137](https://github.com/adobe/log-parser/issues/137) We can now generate an HTML report for the differences in log data.
 

--- a/src/main/java/com/adobe/campaign/tests/logparser/core/AssertLogData.java
+++ b/src/main/java/com/adobe/campaign/tests/logparser/core/AssertLogData.java
@@ -10,6 +10,7 @@ package com.adobe.campaign.tests.logparser.core;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.adobe.campaign.tests.logparser.exceptions.StringParseException;
 import org.hamcrest.Matcher;
@@ -20,6 +21,7 @@ import org.hamcrest.Matcher;
 public class AssertLogData {
 
     public static final String ASSERTION_FAILURE_COMMENT = "Assertion Failure";
+    public static final String ASSERTION_FAILURE_EMPTY_LOGDATA = "No LogData to assert.";
 
     protected AssertLogData() {
         throw new IllegalStateException("Utility class");
@@ -159,6 +161,16 @@ public class AssertLogData {
      *        {@link StdLogEntry}
      */
     public static <T extends StdLogEntry> void assertLogContains(String in_comment, LogData<T> in_logData, Map<String, Matcher> in_conditions) {
+        if (in_logData.getEntries().isEmpty()) {
+            throw new AssertionError(ASSERTION_FAILURE_EMPTY_LOGDATA);
+        }
+
+        in_conditions.keySet().stream().forEach(k -> {
+            if (in_logData.fetchParseDefinition().getDefinitionEntries().stream().noneMatch(pde -> k.equals(pde.getTitle()))) {
+                throw new AssertionError("No Parse Definition Entry found for the given key "+ k +".");
+            }
+        });
+
         if (!in_logData.isEntryPresent(in_conditions)) {
             throw new AssertionError(in_comment);
         }

--- a/src/main/java/com/adobe/campaign/tests/logparser/core/AssertLogData.java
+++ b/src/main/java/com/adobe/campaign/tests/logparser/core/AssertLogData.java
@@ -30,7 +30,7 @@ public class AssertLogData {
      * value for a definition
      * <p>
      * Author : gandomi
-     * @deprecated Use {@link AssertLogData#assertThatLog(LogData, String, Matcher)} instead
+     * @deprecated Use {@link AssertLogData#assertLogContains(LogData, String, Matcher)} instead
      * <p>
      * @param in_logData
      *        A Log data object
@@ -54,7 +54,7 @@ public class AssertLogData {
      * value for a definition
      * <p>
      * Author : gandomi
-     * @deprecated Use {@link AssertLogData#assertThatLog(String, LogData, String, Matcher)} instead
+     * @deprecated Use {@link AssertLogData#assertLogContains(String, LogData, String, Matcher)} instead
      * <p>
      * @param in_comment
      *        A comment that is presented whenever the assertion fails
@@ -81,7 +81,7 @@ public class AssertLogData {
      * value for a definition
      * <p>
      * Author : gandomi
-     * @deprecated Use {@link AssertLogData#assertThatLog(LogData, String, Matcher)} instead
+     * @deprecated Use {@link AssertLogData#assertLogContains(LogData, String, Matcher)} instead
      * <p>
      * @param in_logData
      *        A Log data object
@@ -119,8 +119,8 @@ public class AssertLogData {
      *        The type of the LogData. The type should be a child of
      *        {@link StdLogEntry}
      */
-    public static <T extends StdLogEntry> void assertThatLog(LogData<T> in_logData, String in_parseDefinitionEntryTitle, Matcher<String> in_condition) {
-        assertThatLog(ASSERTION_FAILURE_COMMENT, in_logData, in_parseDefinitionEntryTitle, in_condition);
+    public static <T extends StdLogEntry> void assertLogContains(LogData<T> in_logData, String in_parseDefinitionEntryTitle, Matcher<String> in_condition) {
+        assertLogContains(ASSERTION_FAILURE_COMMENT, in_logData, in_parseDefinitionEntryTitle, in_condition);
     }
 
 
@@ -140,8 +140,8 @@ public class AssertLogData {
      *        The type of the LogData. The type should be a child of
      *        {@link StdLogEntry}
      */
-    public static <T extends StdLogEntry> void assertThatLog(String in_comment, LogData<T> in_logData, String in_parseDefinitionEntryTitle, Matcher<String> in_condition) {
-        assertThatLog(in_comment, in_logData, Map.of(in_parseDefinitionEntryTitle, in_condition));
+    public static <T extends StdLogEntry> void assertLogContains(String in_comment, LogData<T> in_logData, String in_parseDefinitionEntryTitle, Matcher<String> in_condition) {
+        assertLogContains(in_comment, in_logData, Map.of(in_parseDefinitionEntryTitle, in_condition));
     }
 
     /**
@@ -158,7 +158,7 @@ public class AssertLogData {
      *        The type of the LogData. The type should be a child of
      *        {@link StdLogEntry}
      */
-    public static <T extends StdLogEntry> void assertThatLog(String in_comment, LogData<T> in_logData, Map<String, Matcher> in_conditions) {
+    public static <T extends StdLogEntry> void assertLogContains(String in_comment, LogData<T> in_logData, Map<String, Matcher> in_conditions) {
         if (!in_logData.isEntryPresent(in_conditions)) {
             throw new AssertionError(in_comment);
         }
@@ -177,8 +177,8 @@ public class AssertLogData {
      *        The type of the LogData. The type should be a child of
      *        {@link StdLogEntry}
      */
-    public static <T extends StdLogEntry> void assertThatLog(LogData<T> in_logData, Map<String, Matcher> in_conditions) {
-        assertThatLog(ASSERTION_FAILURE_COMMENT, in_logData, in_conditions);
+    public static <T extends StdLogEntry> void assertLogContains(LogData<T> in_logData, Map<String, Matcher> in_conditions) {
+        assertLogContains(ASSERTION_FAILURE_COMMENT, in_logData, in_conditions);
 
     }
 
@@ -188,7 +188,7 @@ public class AssertLogData {
      * <p>
      * Author : gandomi
      *
-     * @deprecated Use {@link AssertLogData#assertThatLog(LogData, String, Matcher)} instead
+     * @deprecated Use {@link AssertLogData#assertLogContains(LogData, String, Matcher)} instead
      * <p>
      * @param in_comment
      *        A comment that is presented whenever the assertion fails
@@ -216,7 +216,7 @@ public class AssertLogData {
      * let you know if a given entry can be found
      * <p>
      * Author :
-     * @deprecated Use {@link AssertLogData#assertThatLog(LogData, String, Matcher)} instead
+     * @deprecated Use {@link AssertLogData#assertLogContains(LogData, String, Matcher)} instead
      * <p>
      * @param in_filePathList
      *        A list of file paths containing log/generated data
@@ -246,7 +246,7 @@ public class AssertLogData {
      * let you know if a given entry can be found
      *
      * Author : gandomi
-     * @deprecated Use {@link AssertLogData#assertThatLog(LogData, String, Matcher)} instead
+     * @deprecated Use {@link AssertLogData#assertLogContains(LogData, String, Matcher)} instead
      *
      * @param in_comment
      *        A comment that is presented whenever the assertion fails

--- a/src/main/java/com/adobe/campaign/tests/logparser/core/AssertLogData.java
+++ b/src/main/java/com/adobe/campaign/tests/logparser/core/AssertLogData.java
@@ -30,6 +30,7 @@ public class AssertLogData {
      * value for a definition
      * <p>
      * Author : gandomi
+     * @deprecated Use {@link AssertLogData#assertThatLog(LogData, String, Matcher)} instead
      * <p>
      * @param in_logData
      *        A Log data object
@@ -53,6 +54,7 @@ public class AssertLogData {
      * value for a definition
      * <p>
      * Author : gandomi
+     * @deprecated Use {@link AssertLogData#assertThatLog(String, LogData, String, Matcher)} instead
      * <p>
      * @param in_comment
      *        A comment that is presented whenever the assertion fails
@@ -67,6 +69,7 @@ public class AssertLogData {
      *        type should be a child of {@link StdLogEntry}
      *
      */
+    @Deprecated
     public static <T extends StdLogEntry> void assertLogContains(String in_comment, LogData<T> in_logData,
             ParseDefinitionEntry in_parseDefinitionEntry, String in_expectedValue) {
 
@@ -78,6 +81,7 @@ public class AssertLogData {
      * value for a definition
      * <p>
      * Author : gandomi
+     * @deprecated Use {@link AssertLogData#assertThatLog(LogData, String, Matcher)} instead
      * <p>
      * @param in_logData
      *        A Log data object
@@ -89,6 +93,7 @@ public class AssertLogData {
      *        The type of the LogData. The type should be a child of
      *        {@link StdLogEntry}
      */
+    @Deprecated
     public static <T extends StdLogEntry> void assertLogContains(LogData<T> in_logData,
             String in_parseDefinitionEntryTitle, String in_expectedValue) {
 
@@ -114,8 +119,8 @@ public class AssertLogData {
      *        The type of the LogData. The type should be a child of
      *        {@link StdLogEntry}
      */
-    public static <T extends StdLogEntry> void assertThat(LogData<T> in_logData, String in_parseDefinitionEntryTitle, Matcher<String> in_condition) {
-        assertThat(ASSERTION_FAILURE_COMMENT, in_logData, in_parseDefinitionEntryTitle, in_condition);
+    public static <T extends StdLogEntry> void assertThatLog(LogData<T> in_logData, String in_parseDefinitionEntryTitle, Matcher<String> in_condition) {
+        assertThatLog(ASSERTION_FAILURE_COMMENT, in_logData, in_parseDefinitionEntryTitle, in_condition);
     }
 
 
@@ -135,8 +140,8 @@ public class AssertLogData {
      *        The type of the LogData. The type should be a child of
      *        {@link StdLogEntry}
      */
-    public static <T extends StdLogEntry> void assertThat(String in_comment, LogData<T> in_logData, String in_parseDefinitionEntryTitle, Matcher<String> in_condition) {
-        assertThat(in_comment, in_logData, Map.of(in_parseDefinitionEntryTitle, in_condition));
+    public static <T extends StdLogEntry> void assertThatLog(String in_comment, LogData<T> in_logData, String in_parseDefinitionEntryTitle, Matcher<String> in_condition) {
+        assertThatLog(in_comment, in_logData, Map.of(in_parseDefinitionEntryTitle, in_condition));
     }
 
     /**
@@ -153,7 +158,7 @@ public class AssertLogData {
      *        The type of the LogData. The type should be a child of
      *        {@link StdLogEntry}
      */
-    public static <T extends StdLogEntry> void assertThat(String in_comment, LogData<T> in_logData, Map<String, Matcher> in_conditions) {
+    public static <T extends StdLogEntry> void assertThatLog(String in_comment, LogData<T> in_logData, Map<String, Matcher> in_conditions) {
         if (!in_logData.isEntryPresent(in_conditions)) {
             throw new AssertionError(in_comment);
         }
@@ -172,8 +177,8 @@ public class AssertLogData {
      *        The type of the LogData. The type should be a child of
      *        {@link StdLogEntry}
      */
-    public static <T extends StdLogEntry> void assertThat(LogData<T> in_logData, Map<String, Matcher> in_conditions) {
-        assertThat(ASSERTION_FAILURE_COMMENT, in_logData, in_conditions);
+    public static <T extends StdLogEntry> void assertThatLog(LogData<T> in_logData, Map<String, Matcher> in_conditions) {
+        assertThatLog(ASSERTION_FAILURE_COMMENT, in_logData, in_conditions);
 
     }
 
@@ -182,6 +187,8 @@ public class AssertLogData {
      * value for a definition
      * <p>
      * Author : gandomi
+     *
+     * @deprecated Use {@link AssertLogData#assertThatLog(LogData, String, Matcher)} instead
      * <p>
      * @param in_comment
      *        A comment that is presented whenever the assertion fails
@@ -195,6 +202,7 @@ public class AssertLogData {
      *        The type of the LogData. The type should be a child of
      *        {@link StdLogEntry}
      */
+    @Deprecated
     public static <T extends StdLogEntry> void assertLogContains(String in_comment, LogData<T> in_logData,
             String in_parseDefinitionEntryTitle, String in_expectedValue) {
 
@@ -207,7 +215,8 @@ public class AssertLogData {
      * This is an assertion at a file level. Given a set of log files it will
      * let you know if a given entry can be found
      * <p>
-     * Author : gandomi
+     * Author :
+     * @deprecated Use {@link AssertLogData#assertThatLog(LogData, String, Matcher)} instead
      * <p>
      * @param in_filePathList
      *        A list of file paths containing log/generated data
@@ -219,6 +228,7 @@ public class AssertLogData {
      *        The expected value for the entry
      * 
      */
+    @Deprecated
     public static void assertLogContains(List<String> in_filePathList, ParseDefinition in_parseDefinition,
             String in_parseDefinitionEntryTitle, String in_expectedValue) {
         try {
@@ -236,6 +246,7 @@ public class AssertLogData {
      * let you know if a given entry can be found
      *
      * Author : gandomi
+     * @deprecated Use {@link AssertLogData#assertThatLog(LogData, String, Matcher)} instead
      *
      * @param in_comment
      *        A comment that is presented whenever the assertion fails
@@ -249,6 +260,7 @@ public class AssertLogData {
      *        The expected value for the entry
      *        
      */
+    @Deprecated
     public static void assertLogContains(String in_comment, List<String> in_filePathList,
             ParseDefinition in_parseDefinition, String in_parseDefinitionEntryTitle, String in_expectedValue) {
 

--- a/src/main/java/com/adobe/campaign/tests/logparser/core/AssertLogData.java
+++ b/src/main/java/com/adobe/campaign/tests/logparser/core/AssertLogData.java
@@ -9,13 +9,17 @@
 package com.adobe.campaign.tests.logparser.core;
 
 import java.util.List;
+import java.util.Map;
 
 import com.adobe.campaign.tests.logparser.exceptions.StringParseException;
+import org.hamcrest.Matcher;
 
 /**
  * Assertion mechanisms for logs. Using this class you can perform assertions on log data
  */
 public class AssertLogData {
+
+    public static final String ASSERTION_FAILURE_COMMENT = "Assertion Failure";
 
     protected AssertLogData() {
         throw new IllegalStateException("Utility class");
@@ -93,6 +97,84 @@ public class AssertLogData {
 
         assertLogContains(l_assertionErrorComment, in_logData, in_parseDefinitionEntryTitle,
                 in_expectedValue);
+    }
+
+    /**
+     * An assert that lets us see if the log data contains an entry matching a matcher
+     * <p>
+     * Author : gandomi
+     * <p>
+     * @param in_logData
+     *        A Log data object
+     * @param in_parseDefinitionEntryTitle
+     *        A Parse Definition entry used for the log entries in the log data
+     * @param in_condition
+     *        The matcher that should hold true value for the entries
+     * @param <T>
+     *        The type of the LogData. The type should be a child of
+     *        {@link StdLogEntry}
+     */
+    public static <T extends StdLogEntry> void assertThat(LogData<T> in_logData, String in_parseDefinitionEntryTitle, Matcher<String> in_condition) {
+        assertThat(ASSERTION_FAILURE_COMMENT, in_logData, in_parseDefinitionEntryTitle, in_condition);
+    }
+
+
+    /**
+     * An assert that lets us see if the log data contains an entry matching a matcher
+     * <p>
+     * Author : gandomi
+     * <p>
+     * @param in_comment A comment to be displayed when the assertion fails
+     * @param in_logData
+     *        A Log data object
+     * @param in_parseDefinitionEntryTitle
+     *        A Parse Definition entry used for the log entries in the log data
+     * @param in_condition
+     *        The matcher that should hold true value for the entries
+     * @param <T>
+     *        The type of the LogData. The type should be a child of
+     *        {@link StdLogEntry}
+     */
+    public static <T extends StdLogEntry> void assertThat(String in_comment, LogData<T> in_logData, String in_parseDefinitionEntryTitle, Matcher<String> in_condition) {
+        assertThat(in_comment, in_logData, Map.of(in_parseDefinitionEntryTitle, in_condition));
+    }
+
+    /**
+     * An assert that lets us see if the log data contains an entry matching a matcher
+     * <p>
+     * Author : gandomi
+     * <p>
+     * @param in_comment A comment to be displayed when the assertion fails
+     * @param in_logData
+     *        A Log data object
+     * @param in_conditions
+     *        A map definition entry and Matchers
+     * @param <T>
+     *        The type of the LogData. The type should be a child of
+     *        {@link StdLogEntry}
+     */
+    public static <T extends StdLogEntry> void assertThat(String in_comment, LogData<T> in_logData, Map<String, Matcher> in_conditions) {
+        if (!in_logData.isEntryPresent(in_conditions)) {
+            throw new AssertionError(in_comment);
+        }
+    }
+
+    /**
+     * An assert that lets us see if the log data contains an entry matching a matcher
+     * <p>
+     * Author : gandomi
+     * <p>
+     * @param in_logData
+     *        A Log data object
+     * @param in_conditions
+     *        A map definition entry and Matchers
+     * @param <T>
+     *        The type of the LogData. The type should be a child of
+     *        {@link StdLogEntry}
+     */
+    public static <T extends StdLogEntry> void assertThat(LogData<T> in_logData, Map<String, Matcher> in_conditions) {
+        assertThat(ASSERTION_FAILURE_COMMENT, in_logData, in_conditions);
+
     }
 
     /**
@@ -181,5 +263,6 @@ public class AssertLogData {
         }
 
     }
+
 
 }

--- a/src/test/java/com/adobe/campaign/tests/logparser/core/AssertionTests.java
+++ b/src/test/java/com/adobe/campaign/tests/logparser/core/AssertionTests.java
@@ -17,6 +17,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -56,6 +57,13 @@ public class AssertionTests {
         l_cubeData.addEntry(l_inputData2);
 
         AssertLogData.assertLogContains(l_cubeData, l_parseDefinitionEntryKey, "112");
+        AssertLogData.assertThat(l_cubeData, "AAZ", Matchers.equalTo("112"));
+        AssertLogData.assertThat("The log data should contain the expected value", l_cubeData, "AAZ", Matchers.equalTo("112"));
+
+        AssertLogData.assertThat(l_cubeData, Map.of("AAZ", Matchers.equalTo("112")));
+        AssertLogData.assertThat("The log data should contain the expected value", l_cubeData, Map.of("AAZ", Matchers.equalTo("112")));
+
+
         AssertLogData.assertLogContains("This should work", l_cubeData, l_parseDefinitionEntryKey, "112");
 
         AssertLogData.assertLogContains("This should also work", l_cubeData, "AAZ", "112");

--- a/src/test/java/com/adobe/campaign/tests/logparser/core/AssertionTests.java
+++ b/src/test/java/com/adobe/campaign/tests/logparser/core/AssertionTests.java
@@ -9,6 +9,7 @@
 package com.adobe.campaign.tests.logparser.core;
 
 import com.adobe.campaign.tests.logparser.exceptions.StringParseException;
+import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
 import org.mockito.MockedStatic;
@@ -62,7 +63,6 @@ public class AssertionTests {
 
         AssertLogData.assertLogContains(l_cubeData, Map.of("AAZ", Matchers.equalTo("112")));
         AssertLogData.assertLogContains("The log data should contain the expected value", l_cubeData, Map.of("AAZ", Matchers.equalTo("112")));
-
 
         AssertLogData.assertLogContains("This should work", l_cubeData, l_parseDefinitionEntryKey, "112");
 
@@ -174,6 +174,166 @@ public class AssertionTests {
     @Test
     public void testLogDataFactory_NegativeInstatiation() {
         assertThrows(IllegalStateException.class, () -> new AssertLogData());
+    }
+
+    /**
+     * Testing that we correctly create a cube
+     *
+     * Author : gandomi
+     */
+    @Test
+    public void testSimpleAssertionNegativeAssertionFail_gettingCorrectMessage() {
+
+        LogData<GenericEntry> l_cubeData = generateTestData();
+
+        String l_comment = "Failed Comment";
+        try {
+
+            AssertLogData.assertLogContains(l_comment, l_cubeData, "AAZ", Matchers.equalTo("124"));
+        } catch (AssertionError ae) {
+            assertThat("The comment should contain the passed string", ae.getMessage(),
+                    Matchers.containsString(l_comment));
+        }
+
+        try {
+
+            AssertLogData.assertLogContains(l_cubeData, "AAZ", Matchers.equalTo("124"));
+        } catch (AssertionError ae) {
+            assertThat("The comment should contain the passed string", ae.getMessage(),
+                    Matchers.containsString(AssertLogData.ASSERTION_FAILURE_COMMENT));
+        }
+    }
+
+    /**
+     * Testing that we correctly create a cube
+     *
+     * Author : gandomi
+     */
+    @Test
+    public void testSimpleAssertionEmptyLogData() {
+
+        LogData<GenericEntry> l_cubeData = new LogData<>();
+
+        var l_titleFornonExistingPDE = "AAZ";
+        try {
+            AssertLogData.assertLogContains(l_cubeData, l_titleFornonExistingPDE, Matchers.equalTo("112"));
+        } catch (AssertionError ae) {
+            assertThat("The comment should contain the passed string", ae.getMessage(),
+                    Matchers.containsString(AssertLogData.ASSERTION_FAILURE_EMPTY_LOGDATA));
+        }
+
+    }
+
+    /**
+     * Testing that we correctly create a cube
+     *
+     * Author : gandomi
+     */
+    @Test
+    public void testSimpleAssertionNegativeWrongEntryTitle() {
+
+        LogData<GenericEntry> l_cubeData = generateTestData();
+
+        var l_titleFornonExistingPDE = "NonExistingTitle";
+        try {
+            AssertLogData.assertLogContains(l_cubeData, l_titleFornonExistingPDE, Matchers.equalTo("112"));
+        } catch (AssertionError ae) {
+            assertThat("The comment should contain the passed string", ae.getMessage(),
+                    Matchers.containsString("No Parse Definition Entry found for the given key "+ l_titleFornonExistingPDE +"."));
+        }
+
+        var l_titleFornonExistingPDE2 = "NonExistingTitle";
+        try {
+            AssertLogData.assertLogContains("Random comment", l_cubeData, l_titleFornonExistingPDE2, Matchers.equalTo("112"));
+        } catch (AssertionError ae) {
+            assertThat("The comment should contain the passed string", ae.getMessage(),
+                    Matchers.containsString("No Parse Definition Entry found for the given key "+ l_titleFornonExistingPDE2 +"."));
+        }
+
+    }
+
+    @Test
+    public void testSimpleAssertionNegativeWrongEntryTitle2() {
+
+        LogData<GenericEntry> l_cubeData = generateTestData();
+
+        var l_titleFornonExistingPDE = "NonExistingTitle";
+        Map<String, Matcher> l_conditions = Map.of("AAZ", Matchers.equalTo("112"), l_titleFornonExistingPDE,
+                Matchers.emptyString());
+        try {
+            AssertLogData.assertLogContains(l_cubeData, l_conditions);
+        } catch (AssertionError ae) {
+            assertThat("The comment should contain the passed string", ae.getMessage(),
+                    Matchers.containsString(
+                            "No Parse Definition Entry found for the given key " + l_titleFornonExistingPDE + "."));
+        }
+
+        // With comment
+        Map<String, Matcher> l_conditions2 = Map.of("AAZ", Matchers.equalTo("112"), l_titleFornonExistingPDE,
+                Matchers.emptyString());
+        try {
+            AssertLogData.assertLogContains("Random Comment", l_cubeData, l_conditions2);
+        } catch (AssertionError ae) {
+            assertThat("The comment should contain the passed string", ae.getMessage(),
+                    Matchers.containsString(
+                            "No Parse Definition Entry found for the given key " + l_titleFornonExistingPDE + "."));
+        }
+
+    }
+
+    /**
+     * Testing that we correctly create a cube
+     *
+     * Author : gandomi
+     */
+    @Test
+    public void testSimpleAssertionFail() {
+
+        LogData<GenericEntry> l_cubeData = generateTestData();
+
+        String l_comment = "Passed Comment";
+        try {
+
+            AssertLogData.assertLogContains(l_comment, l_cubeData, "AAZ", Matchers.equalTo("124"));
+        } catch (AssertionError ae) {
+            assertThat("The comment should contain the passed string", ae.getMessage(),
+                    Matchers.containsString(l_comment));
+        }
+
+        try {
+            AssertLogData.assertLogContains(l_cubeData, "AAZ", Matchers.equalTo("124"));
+        } catch (AssertionError ae) {
+            assertThat("The comment should contain the passed string", ae.getMessage(),
+                    Matchers.startsWith(AssertLogData.ASSERTION_FAILURE_COMMENT));
+        }
+    }
+
+
+
+    private static LogData<GenericEntry> generateTestData() {
+        ParseDefinition l_definition = new ParseDefinition("tmp");
+        final ParseDefinitionEntry l_parseDefinitionEntryKey = new ParseDefinitionEntry("AAZ");
+        l_definition.addEntry(l_parseDefinitionEntryKey);
+        l_definition.addEntry(new ParseDefinitionEntry("ZZZ"));
+        l_definition.addEntry(new ParseDefinitionEntry("BAU"));
+        l_definition.addEntry(new ParseDefinitionEntry("DAT"));
+        l_definition.defineKeys(l_parseDefinitionEntryKey);
+
+        GenericEntry l_inputData = new GenericEntry(l_definition);
+        l_inputData.getValuesMap().put("AAZ", "12");
+        l_inputData.getValuesMap().put("ZZZ", "14");
+        l_inputData.getValuesMap().put("BAU", "13");
+        l_inputData.getValuesMap().put("DAT", "AA");
+
+        GenericEntry l_inputData2 = new GenericEntry(l_definition);
+        l_inputData2.getValuesMap().put("AAZ", "112");
+        l_inputData2.getValuesMap().put("ZZZ", "114");
+        l_inputData2.getValuesMap().put("BAU", "113");
+        l_inputData2.getValuesMap().put("DAT", "AAA");
+
+        LogData<GenericEntry> l_cubeData = new LogData<>(l_inputData);
+        l_cubeData.addEntry(l_inputData2);
+        return l_cubeData;
     }
 
 }

--- a/src/test/java/com/adobe/campaign/tests/logparser/core/AssertionTests.java
+++ b/src/test/java/com/adobe/campaign/tests/logparser/core/AssertionTests.java
@@ -57,11 +57,11 @@ public class AssertionTests {
         l_cubeData.addEntry(l_inputData2);
 
         AssertLogData.assertLogContains(l_cubeData, l_parseDefinitionEntryKey, "112");
-        AssertLogData.assertThat(l_cubeData, "AAZ", Matchers.equalTo("112"));
-        AssertLogData.assertThat("The log data should contain the expected value", l_cubeData, "AAZ", Matchers.equalTo("112"));
+        AssertLogData.assertThatLog(l_cubeData, "AAZ", Matchers.equalTo("112"));
+        AssertLogData.assertThatLog("The log data should contain the expected value", l_cubeData, "AAZ", Matchers.equalTo("112"));
 
-        AssertLogData.assertThat(l_cubeData, Map.of("AAZ", Matchers.equalTo("112")));
-        AssertLogData.assertThat("The log data should contain the expected value", l_cubeData, Map.of("AAZ", Matchers.equalTo("112")));
+        AssertLogData.assertThatLog(l_cubeData, Map.of("AAZ", Matchers.equalTo("112")));
+        AssertLogData.assertThatLog("The log data should contain the expected value", l_cubeData, Map.of("AAZ", Matchers.equalTo("112")));
 
 
         AssertLogData.assertLogContains("This should work", l_cubeData, l_parseDefinitionEntryKey, "112");

--- a/src/test/java/com/adobe/campaign/tests/logparser/core/AssertionTests.java
+++ b/src/test/java/com/adobe/campaign/tests/logparser/core/AssertionTests.java
@@ -57,11 +57,11 @@ public class AssertionTests {
         l_cubeData.addEntry(l_inputData2);
 
         AssertLogData.assertLogContains(l_cubeData, l_parseDefinitionEntryKey, "112");
-        AssertLogData.assertThatLog(l_cubeData, "AAZ", Matchers.equalTo("112"));
-        AssertLogData.assertThatLog("The log data should contain the expected value", l_cubeData, "AAZ", Matchers.equalTo("112"));
+        AssertLogData.assertLogContains(l_cubeData, "AAZ", Matchers.equalTo("112"));
+        AssertLogData.assertLogContains("The log data should contain the expected value", l_cubeData, "AAZ", Matchers.equalTo("112"));
 
-        AssertLogData.assertThatLog(l_cubeData, Map.of("AAZ", Matchers.equalTo("112")));
-        AssertLogData.assertThatLog("The log data should contain the expected value", l_cubeData, Map.of("AAZ", Matchers.equalTo("112")));
+        AssertLogData.assertLogContains(l_cubeData, Map.of("AAZ", Matchers.equalTo("112")));
+        AssertLogData.assertLogContains("The log data should contain the expected value", l_cubeData, Map.of("AAZ", Matchers.equalTo("112")));
 
 
         AssertLogData.assertLogContains("This should work", l_cubeData, l_parseDefinitionEntryKey, "112");

--- a/src/test/java/com/adobe/campaign/tests/logparser/core/LogDataTest.java
+++ b/src/test/java/com/adobe/campaign/tests/logparser/core/LogDataTest.java
@@ -1355,7 +1355,7 @@ public class LogDataTest {
         int l_nrOfEntries = l_logData.getEntries().keySet().size();
         assertThat("The LogData needs to have been generated", l_nrOfEntries, Matchers.greaterThan(0));
 
-        File l_exportedFile = l_logData.exportLogDataToHTML("Log Results",
+        File l_exportedFile = l_logData.exportLogDataToHTML(Arrays.asList("verb", "path", "frequence"),"Log Results",
                 "logDataExport");
 
         try {


### PR DESCRIPTION
## Description

We now want the log - parser to Hamcrest matchers for the validation

## Related Issue
Fixes issue #57 

## Motivation and Context

The existing assertions were a bit too simple, and instead we chose to use Hamcrest matchers.

## How Has This Been Tested?

unit tests


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
