### PR TITLE
Adding json export

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,12 @@ We have the possibility to export the log data results into an HTML file. This i
 
 You have the possibility to define the data, and order to be exported, the file name and the title of the report.
 
+### Exporting Results to an JSON File
+We have the possibility to export the log data results into an JSON file. This is done by calling the methods `LogData#exportLogDataToJSON`.
+
+You have the possibility to define the data, and order to be exported, the file name and the title of the report.
+
+
 ## Command-line Execution of the Log-Parser
 As of version 1.11.0 we have introduced the possibility of running the log-parser from the command line. This is done by using the executable jar file or executing the main method in maven. 
 

--- a/src/main/java/com/adobe/campaign/tests/logparser/core/LogData.java
+++ b/src/main/java/com/adobe/campaign/tests/logparser/core/LogData.java
@@ -535,26 +535,15 @@ public class LogData<T extends StdLogEntry> {
      */
     public File exportLogDataToJSON(Collection<String> in_headerSet, String in_jsonFileName) throws LogDataExportToFileException {
         File l_exportFile = LogParserFileUtils.createNewFile(in_jsonFileName);
-        List<Map<String, String>> JSONlist = new ArrayList<>();
+        List<Map<String, Object>> jsonList = new ArrayList<>();
+        jsonList.addAll(this.getEntries().values().stream().map(StdLogEntry::fetchValueMap).collect(Collectors.toList()));
 
         try {
-            for (StdLogEntry lt_entry : this.getEntries().values()) {
-                Map lt_values = lt_entry.fetchValueMap();
-                JSONlist.add(lt_values);
-            }
-        }
-        catch (Exception e) {
-            throw new LogDataExportToFileException("Encountered error while extracting the log data.", e);
-        }
-
-        ObjectMapper objectMapper = new ObjectMapper();
-
-        try {
-            objectMapper.writeValue(l_exportFile, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(JSONlist));
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.writeValue(l_exportFile, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonList));
         }
         catch (IOException e) {
             throw new LogDataExportToFileException("Encountered error while exporting the log data to a JSON file.", e);
-
         }
         return l_exportFile;
     }

--- a/src/main/java/com/adobe/campaign/tests/logparser/core/LogData.java
+++ b/src/main/java/com/adobe/campaign/tests/logparser/core/LogData.java
@@ -13,6 +13,7 @@ import com.adobe.campaign.tests.logparser.exceptions.LogDataExportToFileExceptio
 import com.adobe.campaign.tests.logparser.exceptions.LogParserPostManipulationException;
 import com.adobe.campaign.tests.logparser.utils.HTMLReportUtils;
 import com.adobe.campaign.tests.logparser.utils.LogParserFileUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.io.FileUtils;
@@ -487,6 +488,74 @@ public class LogData<T extends StdLogEntry> {
             throw new LogDataExportToFileException("We were unable to write to the file " + l_exportFile.getPath());
         }
 
+        return l_exportFile;
+    }
+
+    /**
+     * Exports the current LogData to a standard JSON file. By default, the file will have an escape version of the Parse
+     * Definition as the name
+     *
+     * @return a JSON file containing the LogData
+     */
+    public File exportLogDataToJSON() throws LogDataExportToFileException {
+        T l_firstEntry = this.fetchFirst();
+
+        if (l_firstEntry != null) {
+            return exportLogDataToJSON(l_firstEntry.fetchHeaders(), l_firstEntry.getParseDefinition().fetchEscapedTitle() + "-export.json");
+        } else {
+            log.warn("No Log data to export. Please load the log data before re-attempting");
+            return null;
+        }
+    }
+
+    /**
+     * Exports the current LogData to a standard JSON file.
+     *
+     * @param in_jsonFileName a filename to store the CSV export
+     * @return a JSON file containing the LogData
+     */
+    public File exportLogDataToJSON(String in_jsonFileName) throws LogDataExportToFileException {
+        T l_firstEntry = this.fetchFirst();
+
+        if (l_firstEntry != null) {
+            return exportLogDataToJSON(l_firstEntry.fetchHeaders(), in_jsonFileName + "-export.json");
+        } else {
+            log.warn("No Log data to export. Please load the log data before re-attempting");
+            return null;
+        }
+    }
+
+    /**
+     * Exports the current LogData to an JSON file
+     *
+     * @param in_headerSet   A set of headers to be used as keys for exporting
+     * @param in_jsonFileName The file name to export
+     * @return a JSON file containing the LogData
+     * @throws LogDataExportToFileException If the file could not be exported
+     */
+    public File exportLogDataToJSON(Collection<String> in_headerSet, String in_jsonFileName) throws LogDataExportToFileException {
+        File l_exportFile = LogParserFileUtils.createNewFile(in_jsonFileName);
+        List<Map<String, String>> JSONlist = new ArrayList<>();
+
+        try {
+            for (StdLogEntry lt_entry : this.getEntries().values()) {
+                Map lt_values = lt_entry.fetchValueMap();
+                JSONlist.add(lt_values);
+            }
+        }
+        catch (Exception e) {
+            throw new LogDataExportToFileException("Encountered error while extracting the log data.", e);
+        }
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try {
+            objectMapper.writeValue(l_exportFile, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(JSONlist));
+        }
+        catch (IOException e) {
+            throw new LogDataExportToFileException("Encountered error while exporting the log data to a JSON file.", e);
+
+        }
         return l_exportFile;
     }
 

--- a/src/main/java/com/adobe/campaign/tests/logparser/core/LogData.java
+++ b/src/main/java/com/adobe/campaign/tests/logparser/core/LogData.java
@@ -511,7 +511,7 @@ public class LogData<T extends StdLogEntry> {
     /**
      * Exports the current LogData to a standard JSON file.
      *
-     * @param in_jsonFileName a filename to store the CSV export
+     * @param in_jsonFileName a filename to store the JSON export
      * @return a JSON file containing the LogData
      */
     public File exportLogDataToJSON(String in_jsonFileName) throws LogDataExportToFileException {

--- a/src/test/java/com/adobe/campaign/tests/logparser/core/LogDataTest.java
+++ b/src/test/java/com/adobe/campaign/tests/logparser/core/LogDataTest.java
@@ -1573,4 +1573,12 @@ public class LogDataTest {
         File l_shouldBeEmpty = l_emptyLogData.exportLogDataToJSON();
         assertThat("The returned file should not exist", l_shouldBeEmpty, Matchers.nullValue());
     }
+
+    @Test
+    public void exportDataToJSON_negativeEmptyDataWithFileName() throws LogDataExportToFileException {
+        String givenFileName = "JSONreport";
+        LogData<GenericEntry> l_emptyLogData = new LogData<>();
+        File l_shouldBeEmpty = l_emptyLogData.exportLogDataToJSON(givenFileName);
+        assertThat("The returned file should not exist", l_shouldBeEmpty, Matchers.nullValue());
+    }
 }

--- a/src/test/java/com/adobe/campaign/tests/logparser/core/LogDataTest.java
+++ b/src/test/java/com/adobe/campaign/tests/logparser/core/LogDataTest.java
@@ -13,7 +13,6 @@ import com.adobe.campaign.tests.logparser.data.SDKCaseNoDefConstructor;
 import com.adobe.campaign.tests.logparser.data.SDKCasePrivateDefConstructor;
 import com.adobe.campaign.tests.logparser.exceptions.*;
 import com.adobe.campaign.tests.logparser.utils.CSVManager;
-import com.adobe.campaign.tests.logparser.utils.JSONManager;
 import com.adobe.campaign.tests.logparser.utils.LogParserFileUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;

--- a/src/test/java/com/adobe/campaign/tests/logparser/core/LogDataTest.java
+++ b/src/test/java/com/adobe/campaign/tests/logparser/core/LogDataTest.java
@@ -1519,4 +1519,58 @@ public class LogDataTest {
             l_exportedFile.delete();
         }
     }
+
+    @Test
+    public void testExportDataToJSON_givenFileName() throws StringParseException, IOException {
+        ParseDefinitionEntry l_verbDefinition2 = new ParseDefinitionEntry();
+
+        l_verbDefinition2.setTitle("verb");
+        l_verbDefinition2.setStart("\"");
+        l_verbDefinition2.setEnd(" /");
+
+        ParseDefinitionEntry l_apiDefinition = new ParseDefinitionEntry();
+
+        l_apiDefinition.setTitle("path");
+        l_apiDefinition.setStart(" /rest/head/");
+        l_apiDefinition.setEnd(" ");
+
+        ParseDefinition l_pDefinition = new ParseDefinition("Simple log");
+        l_pDefinition.setDefinitionEntries(Arrays.asList(l_verbDefinition2, l_apiDefinition));
+        l_pDefinition.defineKeys(Arrays.asList(l_apiDefinition, l_verbDefinition2));
+
+        String l_fileFilter = "simple*.log";
+
+        LogData<GenericEntry> l_logData = LogDataFactory.generateLogData("src/test/resources/nestedDirs/", l_fileFilter,
+                l_pDefinition);
+
+        int l_nrOfEntries = l_logData.getEntries().keySet().size();
+        assertThat("The LogData needs to have been generated", l_nrOfEntries, Matchers.greaterThan(0));
+
+        String givenFileName = "JSONreport";
+
+        File l_exportedFile = l_logData.exportLogDataToJSON(givenFileName);
+
+        assertThat("We successfully created the file", l_exportedFile, notNullValue());
+        assertThat("We successfully created the file", l_exportedFile.exists());
+        assertThat("We successfully created the file correctly", l_exportedFile.isFile());
+        assertThat("Created JSON file is no Empty", l_exportedFile.length() > 0);
+
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            String values = objectMapper.readValue(l_exportedFile, String.class);
+
+            assertThat("JSON file contains correct verb definition", values.contains(l_verbDefinition2.getTitle()));
+            assertThat("JSON file contains correct api definition", values.contains(l_apiDefinition.getTitle()));
+
+        } finally {
+            l_exportedFile.delete();
+        }
+    }
+
+    @Test
+    public void exportDataToJSON_negativeEmptyData() throws LogDataExportToFileException {
+        LogData<GenericEntry> l_emptyLogData = new LogData<>();
+        File l_shouldBeEmpty = l_emptyLogData.exportLogDataToJSON();
+        assertThat("The returned file should not exist", l_shouldBeEmpty, Matchers.nullValue());
+    }
 }

--- a/src/test/java/com/adobe/campaign/tests/logparser/core/LogDataTest.java
+++ b/src/test/java/com/adobe/campaign/tests/logparser/core/LogDataTest.java
@@ -14,6 +14,7 @@ import com.adobe.campaign.tests.logparser.data.SDKCasePrivateDefConstructor;
 import com.adobe.campaign.tests.logparser.exceptions.*;
 import com.adobe.campaign.tests.logparser.utils.CSVManager;
 import com.adobe.campaign.tests.logparser.utils.LogParserFileUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
@@ -22,7 +23,9 @@ import org.hamcrest.Matchers;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.util.*;
 
@@ -1500,10 +1503,18 @@ public class LogDataTest {
 
         File l_exportedFile = l_logData.exportLogDataToJSON();
 
+        assertThat("We successfully created the file", l_exportedFile, notNullValue());
+        assertThat("We successfully created the file", l_exportedFile.exists());
+        assertThat("We successfully created the file correctly", l_exportedFile.isFile());
+        assertThat("Created JSON file is no Empty", l_exportedFile.length() > 0);
+
         try {
-            assertThat("We successfully created the file", l_exportedFile, notNullValue());
-            assertThat("We successfully created the file", l_exportedFile.exists());
-            assertThat("We successfully created the file correctly", l_exportedFile.isFile());
+            ObjectMapper objectMapper = new ObjectMapper();
+            String values = objectMapper.readValue(l_exportedFile, String.class);
+
+            assertThat("JSON file contains correct verb definition", values.contains(l_verbDefinition2.getTitle()));
+            assertThat("JSON file contains correct api definition", values.contains(l_apiDefinition.getTitle()));
+
         } finally {
             l_exportedFile.delete();
         }

--- a/src/test/java/com/adobe/campaign/tests/logparser/core/LogDataTest.java
+++ b/src/test/java/com/adobe/campaign/tests/logparser/core/LogDataTest.java
@@ -13,6 +13,7 @@ import com.adobe.campaign.tests.logparser.data.SDKCaseNoDefConstructor;
 import com.adobe.campaign.tests.logparser.data.SDKCasePrivateDefConstructor;
 import com.adobe.campaign.tests.logparser.exceptions.*;
 import com.adobe.campaign.tests.logparser.utils.CSVManager;
+import com.adobe.campaign.tests.logparser.utils.JSONManager;
 import com.adobe.campaign.tests.logparser.utils.LogParserFileUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
@@ -1472,4 +1473,40 @@ public class LogDataTest {
         assertThat((new LogData<>()).fetchParseDefinition(), Matchers.nullValue());
     }
 
+    @Test
+    public void testExportDataToJSON() throws StringParseException, IOException {
+        ParseDefinitionEntry l_verbDefinition2 = new ParseDefinitionEntry();
+
+        l_verbDefinition2.setTitle("verb");
+        l_verbDefinition2.setStart("\"");
+        l_verbDefinition2.setEnd(" /");
+
+        ParseDefinitionEntry l_apiDefinition = new ParseDefinitionEntry();
+
+        l_apiDefinition.setTitle("path");
+        l_apiDefinition.setStart(" /rest/head/");
+        l_apiDefinition.setEnd(" ");
+
+        ParseDefinition l_pDefinition = new ParseDefinition("Simple log");
+        l_pDefinition.setDefinitionEntries(Arrays.asList(l_verbDefinition2, l_apiDefinition));
+        l_pDefinition.defineKeys(Arrays.asList(l_apiDefinition, l_verbDefinition2));
+
+        String l_fileFilter = "simple*.log";
+
+        LogData<GenericEntry> l_logData = LogDataFactory.generateLogData("src/test/resources/nestedDirs/", l_fileFilter,
+                l_pDefinition);
+
+        int l_nrOfEntries = l_logData.getEntries().keySet().size();
+        assertThat("The LogData needs to have been generated", l_nrOfEntries, Matchers.greaterThan(0));
+
+        File l_exportedFile = l_logData.exportLogDataToJSON();
+
+        try {
+            assertThat("We successfully created the file", l_exportedFile, notNullValue());
+            assertThat("We successfully created the file", l_exportedFile.exists());
+            assertThat("We successfully created the file correctly", l_exportedFile.isFile());
+        } finally {
+            l_exportedFile.delete();
+        }
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding methods for exporting log data into JSON file

## Description
This PR includes methods for exporting log data (LogData) into JSON file.

## Related Issue
https://github.com/adobe/log-parser/issues/173

## Motivation and Context
We have options to export LogData into CSV and HTML, with this code change we can now export data into JSON as well

## How Has This Been Tested?
This is tested by creating new unit test testExportDataToJSON

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
