### PR TITLE
Fixed issue #185 : We now have a string transformer when exporting data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ The basic method for using this library is, that you create a definition for you
 
 ## Table of contents
 <!-- TOC -->
-* [log-parser](#log-parser)
-  * [Table of contents](#table-of-contents)
+
   * [Installation](#installation)
     * [Maven](#maven)
   * [Running the Log Parser](#running-the-log-parser)
@@ -33,6 +32,7 @@ The basic method for using this library is, that you create a definition for you
         * [Declaring the transformation Rules in setValuesFromMap](#declaring-the-transformation-rules-in-setvaluesfrommap)
         * [Declaring the Key](#declaring-the-key)
         * [Declare the HeaderMap, and ValueMap](#declare-the-headermap-and-valuemap)
+        * [Assisting Exports](#assisting-exports)
   * [Code Structure](#code-structure)
   * [Searching and organizing log data](#searching-and-organizing-log-data)
     * [Search and Filter Mechanisms](#search-and-filter-mechanisms)
@@ -47,6 +47,7 @@ The basic method for using this library is, that you create a definition for you
   * [Exporting Parse Results](#exporting-parse-results)
     * [Exporting Results to a CSV File](#exporting-results-to-a-csv-file)
     * [Exporting Results to an HTML File](#exporting-results-to-an-html-file)
+    * [Exporting Results to an JSON File](#exporting-results-to-an-json-file)
   * [Command-line Execution of the Log-Parser](#command-line-execution-of-the-log-parser)
   * [Changelog](#changelog)
     * [1.11.0 (next version)](#1110--next-version-)
@@ -256,6 +257,10 @@ Depending on the fields you have defined, you will want to define how the result
 
 You will need to give names to the headers, and provide a map that extracts the values.
 
+##### Assisting Exports
+One of the added values of writing your own log data is the possibility of using non-String objects, and perform additional operations on the data. This has the drawback that we can have odd behaviors when exporting the logs data. For this we, y default, transforml all data in an entry to a map of Strings.
+
+In some cases the default String transformation may not be to your liking. In this case you will have to override the method `Map<String, String> fetchValueMapPrintable()`. To do this the method needs to call perform your own transformation to the results of the `fetchValueMap()` method. 
 
 ## Code Structure
 Below is a diagram representing the class structure:
@@ -420,6 +425,8 @@ We have the possibility to export the log data results into files. Currently the
 
 All reports are stored in the directory `log-parser-reports/export/`.
 
+If you are using an SDK to control the log parsing, you may want to override the method `fetchValueMapPrintable` to provide a more suitable export of the data. For mor information on this please refer to the chapter describing this topic.
+
 ### Exporting Results to a CSV File
 We have the possibility to export the log data results into a CSV file. This is done by calling the methods `LogData#exportLogDataToCSV`.
 
@@ -434,7 +441,6 @@ You have the possibility to define the data, and order to be exported, the file 
 We have the possibility to export the log data results into an JSON file. This is done by calling the methods `LogData#exportLogDataToJSON`.
 
 You have the possibility to define the data, and order to be exported, the file name and the title of the report.
-
 
 ## Command-line Execution of the Log-Parser
 As of version 1.11.0 we have introduced the possibility of running the log-parser from the command line. This is done by using the executable jar file or executing the main method in maven. 
@@ -480,6 +486,8 @@ All reports are stored in the directory `log-parser-reports/export/`.
 - [#57](https://github.com/adobe/log-parser/issues/57) Assertions are no longer an implicite assert equal method. We now allow Hamcrest Matchers for asserting. This can be one or more matchers.
 - [#119](https://github.com/adobe/log-parser/issues/119) Cleanup of deprecated methods, and the consequences thereof.
 - [#137](https://github.com/adobe/log-parser/issues/137) We can now generate an HTML report for the differences in log data.
+- [#185](https://github.com/adobe/log-parser/issues/185) Resolved issue with deserializing unexpected objects in SDK Log entries..
+
 
 ### 1.0.10
 - Moved main code and tests to the package "core"

--- a/pom.xml
+++ b/pom.xml
@@ -336,18 +336,6 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.17.2</version>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-parameter-names</artifactId>
-            <version>2.17.2</version>
-        </dependency>
-
-        <!--	Java 8 Date/time	-->
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.17.2</version>
-        </dependency>
         <!-- Using 4.11.0 because we want to keep Java8 compatibility -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,18 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.17.2</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
+            <version>2.17.2</version>
+        </dependency>
+
+        <!--	Java 8 Date/time	-->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.17.2</version>
+        </dependency>
         <!-- Using 4.11.0 because we want to keep Java8 compatibility -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/com/adobe/campaign/tests/logparser/core/LogData.java
+++ b/src/main/java/com/adobe/campaign/tests/logparser/core/LogData.java
@@ -13,12 +13,7 @@ import com.adobe.campaign.tests.logparser.exceptions.LogDataExportToFileExceptio
 import com.adobe.campaign.tests.logparser.exceptions.LogParserPostManipulationException;
 import com.adobe.campaign.tests.logparser.utils.HTMLReportUtils;
 import com.adobe.campaign.tests.logparser.utils.LogParserFileUtils;
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.io.FileUtils;

--- a/src/main/java/com/adobe/campaign/tests/logparser/core/LogData.java
+++ b/src/main/java/com/adobe/campaign/tests/logparser/core/LogData.java
@@ -542,7 +542,8 @@ public class LogData<T extends StdLogEntry> {
 
         try {
             ObjectMapper objectMapper = new ObjectMapper();
-            objectMapper.writeValue(l_exportFile, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonList));
+            objectMapper.writeValue(l_exportFile,
+                    objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonList));
         } catch (IOException e) {
             throw new LogDataExportToFileException("Encountered error while exporting the log data to a JSON file.", e);
         }

--- a/src/main/java/com/adobe/campaign/tests/logparser/core/LogData.java
+++ b/src/main/java/com/adobe/campaign/tests/logparser/core/LogData.java
@@ -542,8 +542,7 @@ public class LogData<T extends StdLogEntry> {
 
         try {
             ObjectMapper objectMapper = new ObjectMapper();
-            objectMapper.writeValue(l_exportFile,
-                    objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonList));
+            objectMapper.writeValue(l_exportFile, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonList));
         } catch (IOException e) {
             throw new LogDataExportToFileException("Encountered error while exporting the log data to a JSON file.", e);
         }

--- a/src/main/java/com/adobe/campaign/tests/logparser/core/StdLogEntry.java
+++ b/src/main/java/com/adobe/campaign/tests/logparser/core/StdLogEntry.java
@@ -134,6 +134,18 @@ public abstract class StdLogEntry {
     }
 
     /**
+     * For deserialization purposes, when people define their own classes we will need to have a map of Strings. This
+     * avoids problems when exporting data. In cases where this cannot be done automatically, please overload this
+     * method.
+     *
+     * @return a map of Strings representing the values of the log entry
+     */
+     protected Map<String, String> fetchValueMapPrintable() {
+        return fetchValueMap().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> Optional.ofNullable(e.getValue()).orElse("").toString()));
+    }
+
+    /**
      * Increments the frequence
      *
      * Author : gandomi

--- a/src/test/java/com/adobe/campaign/tests/logparser/core/SDKTests.java
+++ b/src/test/java/com/adobe/campaign/tests/logparser/core/SDKTests.java
@@ -8,27 +8,24 @@
  */
 package com.adobe.campaign.tests.logparser.core;
 
-
-import com.adobe.campaign.tests.logparser.data.SDKCaseBadDefConstructor;
-import com.adobe.campaign.tests.logparser.data.SDKCasePrivateDefConstructor;
-import com.adobe.campaign.tests.logparser.data.SDKCaseNoDefConstructor;
-import com.adobe.campaign.tests.logparser.data.SDKCaseSTD;
+import com.adobe.campaign.tests.logparser.data.*;
 import com.adobe.campaign.tests.logparser.exceptions.IncorrectParseDefinitionException;
 import com.adobe.campaign.tests.logparser.exceptions.LogDataExportToFileException;
 import com.adobe.campaign.tests.logparser.exceptions.LogParserSDKDefinitionException;
 import com.adobe.campaign.tests.logparser.exceptions.StringParseException;
-import org.hamcrest.Matcher;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 public class SDKTests {
 
@@ -192,6 +189,57 @@ public class SDKTests {
         Assert.assertThrows(LogParserSDKDefinitionException.class,
                 () -> LogDataFactory.generateLogData(Arrays.asList(l_file), l_pDefinition,
                         SDKCasePrivateDefConstructor.class));
+
+    }
+
+
+    @Test
+    public void testFetchValueMapToString() throws StringParseException {
+        ParseDefinition l_pDefinition = SDKTests.getTestParseDefinition();
+        l_pDefinition.setStoreFileName(true);
+
+        String l_file = "src/test/resources/sdk/useCase1.log";
+
+        LogData<SDKCase2> l_entries = LogDataFactory.generateLogData(Arrays.asList(l_file), l_pDefinition,
+                SDKCase2.class);
+
+        SDKCase2 l_entry = l_entries.getEntries().values().iterator().next();
+
+        assertThat("Checking the original assumptions",l_entry.fetchValueMap().get("timeOfLog"), instanceOf(
+                ZonedDateTime.class));
+
+        assertThat("Checking the original assumptions",l_entry.fetchValueMapPrintable().get("timeOfLog"), instanceOf(
+                String.class));
+
+
+    }
+
+    @Test
+    public void testSimpleLogACC_SDK_exportDateTimeJSON() throws StringParseException, IOException {
+        ParseDefinition l_pDefinition = SDKTests.getTestParseDefinition();
+        l_pDefinition.setStoreFileName(true);
+
+        String l_file = "src/test/resources/sdk/useCase1.log";
+
+        LogData<SDKCase2> l_entries = LogDataFactory.generateLogData(Arrays.asList(l_file), l_pDefinition,
+                SDKCase2.class);
+
+        File l_exportedFile = l_entries.exportLogDataToJSON("jsonTest.json");
+
+        assertThat("We successfully created the file", l_exportedFile, notNullValue());
+        assertThat("We successfully created the file", l_exportedFile.exists());
+        assertThat("We successfully created the file correctly", l_exportedFile.isFile());
+        assertThat("Created JSON file is no Empty", l_exportedFile.length() > 0);
+
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            String values = objectMapper.readValue(l_exportedFile, String.class);
+
+            assertThat("JSON file contains correct verb definition", values.contains("\"timeStamp\" : \"2024-06-13T03:00:19.727Z\""));
+
+        } finally {
+            l_exportedFile.delete();
+        }
 
     }
 

--- a/src/test/java/com/adobe/campaign/tests/logparser/core/SDKTests.java
+++ b/src/test/java/com/adobe/campaign/tests/logparser/core/SDKTests.java
@@ -14,8 +14,6 @@ import com.adobe.campaign.tests.logparser.exceptions.LogDataExportToFileExceptio
 import com.adobe.campaign.tests.logparser.exceptions.LogParserSDKDefinitionException;
 import com.adobe.campaign.tests.logparser.exceptions.StringParseException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.hamcrest.Matchers;
-import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Due to errors when serializing unexpected objects, we have chosen to transform all data to String when exporting.

## Related Issue

Fixes #185 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
